### PR TITLE
Initialize $DCFilesExists in 2_CreateParentDisks.ps1

### DIFF
--- a/Scripts/2_CreateParentDisks.ps1
+++ b/Scripts/2_CreateParentDisks.ps1
@@ -376,7 +376,8 @@ If (!( $isAdmin )) {
             WriteInfo "`t Tools.vhdx not found, will be created"
         }
 
-    #check if DC exists
+    #check if DC exists. Set explicitly to $false in case of running the script multipe times in same PS Session
+        $DCFilesExists=$False
         if (Get-ChildItem -Path "$PSScriptRoot\LAB\DC\" -Recurse -ErrorAction SilentlyContinue){
             $DCFilesExists=$true
             WriteInfoHighlighted "Files found in $PSScriptRoot\LAB\DC\. DC Creation will be skipped"


### PR DESCRIPTION
I ran the script a few times in the same PS Session and got into an error because $DCFilesExists was still $true from the previous run